### PR TITLE
fix: Make sure lists properly render by having a preceding empty line

### DIFF
--- a/docs/advanced/computer.md
+++ b/docs/advanced/computer.md
@@ -5,6 +5,7 @@ There are many computer-core specific features and functionality to go over. Her
 Starting from 2018 may 7 release MiSTer supports serial (UART) connection from FPGA to Linux. Linux OS runs PPP or Console daemon on this connection allowing access the internet or Linux shell from FPGA cores.
 
 ## Cores supporting serial connection
+
 * **Minimig**. Tested on [Roadshow TCP/IP](https://misterfpga.org/viewtopic.php?f=4&t=2063&p=18598&hilit=Roadshow#p18598){target=_blank}, AmiTCP and Miami. 
     1. AmiTCP provides more complete solution with ftpd daemon. There are many other 3rd party addons are based on AmiTCP, so it's advised to use this package.
     2. Roadshow works very well, it is fully compatible with AmiTCP and offers additional extensions. Follow these [Instructions](https://misterfpga.org/viewtopic.php?f=4&t=2063&p=18598&hilit=Roadshow#p18598){target=_blank} for complete setup.  It is still a paid for and supported product, you can find more information [here](http://roadshow.apc-tcp.de/index-en.php){target=_blank}.

--- a/docs/advanced/lag.md
+++ b/docs/advanced/lag.md
@@ -3,6 +3,7 @@ A common concern among retro enthusiasts is whether a device of this sort has _l
 Every electronic equipment exhibits some kind of _latency_, but it only becomes problematic if this latency causes frames to be missed. A frame is typically 16ms for a system using a 60 frames per second (60 Hz) display.
 
 Lag is only problematic in a few specific cases:
+
 * Some older games were designed to rely on extremely quick response times (e.g. Punch-Out on NES).
 * If the latency is different between two players, it could introduce an unfair advantage.
 * Lag that isn't constant can be an issue on games that require precise movement. (Most players can adapt to lag that is consistent.)

--- a/docs/advanced/multibutton.md
+++ b/docs/advanced/multibutton.md
@@ -41,12 +41,14 @@ Assume a six button arcade controller (for Street Fighter 2) with 3 punch button
 We will map the buttons so that Breakers / Breakers' revenge has the same kind of layout.
 
 This particular game uses the following attack buttons:
+
 * A: Weak Punch
 * B: Weak Kick
 * C: Strong Punch
 * D: Strong Kick
 
 In addition, most characters have an extra "command" move mapped to:
+
 * Weak Punch + Strong Punch 
 * Weak Kick + Strong Kick 
 

--- a/docs/advanced/network.md
+++ b/docs/advanced/network.md
@@ -16,20 +16,28 @@ A project was launched that makes it easier to get a network attached storage (N
 
 ## Static IP Address configuration
 Currently the best way to do this is using `connmanctl` (try `connmanctl help` for more info).
+
 * Create /var/lib/connman directory so changes will persist across reboots  
+
 ```
 # mkdir /var/lib/connman
 ```
-* Find your on-board network service name.  
+
+* Find your on-board network service name.
+  
 ```
 # connmanctl services
 *AO Wired                ethernet_020304050607_cable
 ```
-* Setup IP address (e.g. `192.168.1.123`, should be unused), subnet mask (e.g. `255.255.255.0`) and gateway (e.g. `192.168.1.1`, typically your router IP address). To configure the right device use the service name returned from above command (e.g. `ethernet_020304050607_cable`). This will disable the use of DHCP.  
+
+* Setup IP address (e.g. `192.168.1.123`, should be unused), subnet mask (e.g. `255.255.255.0`) and gateway (e.g. `192.168.1.1`, typically your router IP address). To configure the right device use the service name returned from above command (e.g. `ethernet_020304050607_cable`). This will disable the use of DHCP.
+ 
 ```
 # connmanctl config ethernet_020304050607_cable --ipv4 manual 192.168.1.123 255.255.255.0 192.168.1.1
 ```
-* Setup one or more DNS server(s) (e.g. `192.168.1.1` from your router, `8.8.8.8` from Google DNS.  
+
+* Setup one or more DNS server(s) (e.g. `192.168.1.1` from your router, `8.8.8.8` from Google DNS.
+
 ```
 # connmanctl config ethernet_020304050607_cable --nameservers 192.168.1.1 8.8.8.8
 ```

--- a/docs/advanced/rtc.md
+++ b/docs/advanced/rtc.md
@@ -42,6 +42,7 @@ The following section will walk you through the steps of creating your own Miste
 ### 1. Order PCB
 
 #### Approved PCB Manufactors
+
   * [PCBway](https://www.pcbway.com/setinvite.aspx?inviteid=43024){target=_blank} - [Quick order RTC v1.2](https://www.pcbway.com/project/shareproject/RTC_for_MiSTer_v1_2.html){target=_blank} - [Quick order RTC v1.3 (with temp sensor)](https://www.pcbway.com/project/shareproject/W43024ASU40_rtc_1_3.html){target=_blank}
   * [EasyEDA](https://easyeda.com/){target=_blank}
   * [JLCPCB](https://jlcpcb.com/){target=_blank}

--- a/docs/basics/input.md
+++ b/docs/basics/input.md
@@ -1,6 +1,7 @@
 MiSTer has support for a wide variety of input devices. It also has options to configure these devices to fit your needs in addition to several quality of life features across most, sometimes all, cores. Here is a breakdown of some special configurations for various input devices like spinners, gamepads, joysticks, and keyboards.
 
 MiSTer has a set of standard features for USB gaming controllers:
+
 * Up to 6 player support
 * Auto Fire
 * Mouse emulation from your joystick
@@ -59,6 +60,7 @@ The lightgun needs to be calibrated in each core:
 * It is recommended to load a game and calibrate to the edges of the image, rather than the entire (widescreen) TV
   
 ### Joy1/Joy2 assignment
+
 * This setting needs to match the player number your lightgun is currently assigned within the core. See [Default Joystick Player Assignment Method](#default-joystick-player-assignment-method)
 * Some systems had their lightguns connect to player 2, eg NES, SNES, Genesis. Many games from these systems will also work with the lightgun assigned as player 1 (Joy1), however some require a normal controller as player 1 and the lightgun as player 2 (Joy2). 
 

--- a/docs/basics/keyboard.md
+++ b/docs/basics/keyboard.md
@@ -12,16 +12,19 @@ To switch between emulation modes press ++num-lock++ or ++scroll-lock++ until th
 The switching sequence is `Mouse >> Joy1 >> Joy2 >> None`
 
 The LEDs on your keyboard will display the emulation modes:
+
 * Mouse emulation: NumLock LED + ScrLock LED
 * Joystick 1 emulation: NumLock LED.
 * Joystick 2 emulation: ScrLock LED.
 
 ## Common functional keys/combos used in cores
+
 * ++f12++ - open/close OSD menu/submenu
 * ++alt+f12++ - quick core selection (like in Menu core).
 * ++lctrl+lalt+ralt++ - presses the "USER" button which usually is reset in emulated system.
 * ++lshift+lctrl+lalt+ralt++ - MiSTer reset (load Menu core).
 
 ### Notes:
+
 * Some systems provide writing support which requires additional attention to how you reset/shutdown the MiSTer. MiSTer tries not to keep any pending writes and writes physically to the disk as soon as possible. Still, safer way to reset the MiSTer from core which probably was writing to disk recently is using combo ++lshift+lctrl+lalt+ralt++ - this will flush all caches to disk before restart. Cores without write can be restarted by hard reset button or powered down without special attention.
 * ++lctrl+lalt+ralt++ sequence can be replaced by some other well known combos through INI file.

--- a/docs/basics/links.md
+++ b/docs/basics/links.md
@@ -5,6 +5,7 @@ Here's a collection of links to various information, videos, and articles about 
 Otherwise there are some older videos listed below.
 
 ## MiSTer FPGA Articles
+
 * [Polygon - MiSTer 101: A classic gaming device to rule them all by Christopher Grant](https://www.polygon.com/22640171/mister-project-classic-gaming-retro-fpga-board-chip-io-explainer-usb-hub){target=_blank} - August 8, 2021
 * [Kotaku - And Now, The Ultimate Retro Gaming Device by Mike Fahey](https://kotaku.com/and-now-the-ultimate-retro-gaming-device-1847608362){target=_blank} - September 02, 2021
 * [Edge Magazine Australia - Hard Core: How MiSTer emulation is redefining the art of resurrecting gaming's past by Alex Wiltshire](https://www.pressreader.com/australia/edge/20210422/284249533161844){target=_blank} - April 22, 2021
@@ -13,6 +14,7 @@ Otherwise there are some older videos listed below.
 * [Dream Machine: MiSTer FPGA by Félix Léger (@felleg)](https://felixleger.com/posts/2020/10/dream-machine-mister-fpga/){target=_blank} - October 18, 2020
 
 ## Tutorials/Guides
+
 * [MiSTer Manual by adreeve](https://github.com/adreeve/MiSTerManual){target=_blank}
 
 ## MiSTer FPGA Videos
@@ -43,5 +45,6 @@ Otherwise there are some older videos listed below.
 * [Sep 2019 - SmokeMonster - FPGA Revolution](https://www.youtube.com/watch?v=X2G0WJ-Z9tk){target=_blank}
 
 ## Other / Demonstrations
+
 * [Jul 2020 - RetroManCave - My Ultimate FPGA Desktop](https://www.youtube.com/watch?v=TCQuUwHH45w){target=_blank}
 

--- a/docs/cores/highlights/genesis.md
+++ b/docs/cores/highlights/genesis.md
@@ -1,6 +1,7 @@
 The Genesis core is a port of the [fpgagen](https://github.com/Torlus/fpgagen){target=_blank} core to MiSTer, with significant enhancements and additions. The audio filtering options have been adjusted according to real hardware using [MDFourier](https://junkerhq.net/MDFourier/){target=_blank}.
 
 ## Features
+
 * Composite Blending effect (e.g. Sonic Waterfall transparency)
 * CPU Turbo option (e.g. Road Rash gameplay speed)
 * Increase sprite limit.

--- a/docs/cores/highlights/megacd.md
+++ b/docs/cores/highlights/megacd.md
@@ -1,6 +1,7 @@
 The MegaCD core is a MiSTer project original core developed by [srg320 (Sergey Dvodnenko)](https://www.patreon.com/srg320/){target=_blank} which aims to simulate the Sega CD / Mega CD add-on for the Sega Genesis. It uses the same [fpgagen](https://github.com/Torlus/fpgagen){target=_blank} logic and many of the improvements to it made in the MiSTer Genesis core, but adds on a significant chunk of logic that handles the powerful CD addon hardware.
 
 ## Features
+
 * Almost all features from the [Genesis core](genesis.md)
 * CUE/BIN support.
 * CHD support.

--- a/docs/developer/analogsim.md
+++ b/docs/developer/analogsim.md
@@ -108,12 +108,14 @@ The [Arcade-Battlezone](https://github.com/jopdorp/Arcade-BattleZone_MiSTer){tar
 [MiSTer - Head On](headonsoundpcb.md)
 
 ### Informational resources
+
 * For finding the right values of a filter: [https://www.micromodeler.com/dsp/](https://www.micromodeler.com/dsp/){target=_blank}
 * Common operational amplifier uses, such as differentiators and integrators: [https://en.wikipedia.org/wiki/Operational_amplifier_applications](https://en.wikipedia.org/wiki/Operational_amplifier_applications){target=_blank}
 * Explanation of how 555 timers work: [https://www.electronics-tutorials.ws/waveforms/555_oscillator.html](https://www.electronics-tutorials.ws/waveforms/555_oscillator.html){target=_blank}
 * Spice programming [https://www.allaboutcircuits.com/textbook/reference/chpt-7/fundamentals-spice-programming/](https://www.allaboutcircuits.com/textbook/reference/chpt-7/fundamentals-spice-programming/){target=_blank}
 
 ### Code examples
+
 * [example of a noise-based sound python implementation in a notebook](https://github.com/jopdorp/Arcade-BattleZone_MiSTer/blob/sound/spice/Red%20baron%20crash%20circuit%20sim.ipynb){target=_blank}
 * [example of a piece of python code that generates a lookup table](https://github.com/jopdorp/Arcade-BattleZone_MiSTer/blob/sound/rtl/generate_control_coltages_to_frequency.py){target=_blank}
 * [example of a common digital noise generator](https://github.com/jopdorp/Arcade-BattleZone_MiSTer/blob/sound/rtl/noise_source_shell_explo.sv){target=_blank}
@@ -122,6 +124,7 @@ The [Arcade-Battlezone](https://github.com/jopdorp/Arcade-BattleZone_MiSTer){tar
 * [example of a spice netlist for a noise based sound](https://github.com/jopdorp/Arcade-BattleZone_MiSTer/blob/sound/spice/bang.cir){target=_blank}
 
 ### Tooling
+
 * [https://www.falstad.com/circuit/](https://www.falstad.com/circuit/){target=_blank}
 * [http://ngspice.sourceforge.net/](http://ngspice.sourceforge.net/){target=_blank}
 * [https://www.audacityteam.org/](https://www.audacityteam.org/){target=_blank}

--- a/docs/developer/component.md
+++ b/docs/developer/component.md
@@ -2,6 +2,7 @@ This is a list of many recreated components used in various MiSTer FPGA cores.
 
 ## AMI
 ### POKEY Sound Chip
+
 * [Atari 5200 & 800](https://github.com/MiSTer-devel/Atari800_MiSTer){target=_blank}
 * [Arcade - A Tetris](https://github.com/MiSTer-devel/Arcade-ATetris_MiSTer){target=_blank}
 * [Arcade - Black Widow](https://github.com/MiSTer-devel/Arcade-BlackWidow_MiSTer){target=_blank}
@@ -10,54 +11,68 @@ This is a list of many recreated components used in various MiSTer FPGA cores.
 
 ## AMP 
 ### IR3R60N Audio
+
 * [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer){target=_blank}
 
 ## Atari
 ### ANTIC Alphanumeric Television Interface Controller
+
 * [Atari 5200 & 800](https://github.com/MiSTer-devel/Atari800_MiSTer){target=_blank}
 * [Atari 7800](https://github.com/MiSTer-devel/Atari7800_MiSTer){target=_blank}
 
 ### MARIA Custom Graphics Chip
+
 * [Atari 7800](https://github.com/MiSTer-devel/Atari7800_MiSTer){target=_blank}
 
 ### TIA Television Interface Adapter
+
 * [Atari 2600](https://github.com/MiSTer-devel/Atari2600_MiSTer){target=_blank} TIA 
 * [Atari 5200 & 800](https://github.com/MiSTer-devel/Atari800_MiSTer){target=_blank} CTIA - Character TIA
 * [Atari 7800](https://github.com/MiSTer-devel/Atari7800_MiSTer){target=_blank} GTIA - Graphics TIA
 
 ### XEGS Keyboard Support
+
 * [Atari 7800](https://github.com/MiSTer-devel/Atari7800_MiSTer){target=_blank}
 
 ## ARM
 ### ARM7TDMI
+
 * [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer){target=_blank}
 
 ## Chip8
+
 * [Chip 8](https://github.com/MiSTer-devel/Chip8_MiSTer){target=_blank}
 
 ## EEPROM
+
 * [Arduboy](https://github.com/MiSTer-devel/Arduboy_MiSTer){target=_blank}
 
 ## General Instrument
 ### PONG on a chip
+
 * [AY-3-8500](https://github.com/MiSTer-devel/AY-3-8500-MiSTer){target=_blank}
 
 ### AY-3-8900
+
 * [Intellivision](https://github.com/MiSTer-devel/Intv_MiSTer){target=_blank}
 
 ### AY-3-8900-1
+
 * [Intellivision](https://github.com/MiSTer-devel/Intv_MiSTer){target=_blank}
 
 ### AY-3-8912 Sound
+
 * [Vectrex](https://github.com/MiSTer-devel/Vectrex_MiSTer){target=_blank} MC68A09
 
 ### AY-3-8917 Sound Generator
+
 * [Intellivision](https://github.com/MiSTer-devel/Intv_MiSTer){target=_blank}
 
 ### CP1610 
 * [Intellivision](https://github.com/MiSTer-devel/Intv_MiSTer){target=_blank}
 
 ### SP0256-012
+
 * [Intellivision](https://github.com/MiSTer-devel/Intv_MiSTer){target=_blank}
 
 ## GPIO
@@ -65,40 +80,50 @@ This is a list of many recreated components used in various MiSTer FPGA cores.
 See: [Cores supporting RTC](../cores/features/rtcsupport.md){target=_blank}
 
 ### Solar Sensor
+
 * [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer){target=_blank}
 
 ### Gyroscope
+
 * [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer){target=_blank}
 
 ### Tilt
+
 * [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer){target=_blank}
 
 ## Hitachi 
 ### HG51B169 - SNES Cart IC CX4
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank}
 
 ## Intel
 ### 8035 - No ROM version of 8048
+
 * [Arcade - Donkey Kong](https://github.com/MiSTer-devel/Arcade-DonkeyKong_MiSTer){target=_blank} i8035ip for audio
 * [Arcade - Donkey Kong Jr.](https://github.com/MiSTer-devel/Arcade-DonkeyKongJunior_MiSTer){target=_blank} i8035ip for audio
 
 ### 8048 (T48)
+
 * [Odyssey 2](https://github.com/MiSTer-devel/Odyssey2_MiSTer){target=_blank}
 * [Arcade - Donkey Kong](https://github.com/MiSTer-devel/Arcade-DonkeyKong_MiSTer){target=_blank}
 * [Arcade - Donkey Kong Jr.](https://github.com/MiSTer-devel/Arcade-DonkeyKongJunior_MiSTer){target=_blank} T80
 
 ### 8244 NTSC & Audio
+
 * [Odyssey 2](https://github.com/MiSTer-devel/Odyssey2_MiSTer){target=_blank}
 
 ### 8245 PAL & Audio
+
 * [Odyssey 2](https://github.com/MiSTer-devel/Odyssey2_MiSTer){target=_blank}
 
 ## Microchip
 ### ATMega / ATXMega
+
 * [Arduboy](https://github.com/MiSTer-devel/Arduboy_MiSTer){target=_blank}
 
 ## MOS 
 ### 6502 (and variants)
+
 * [Arcade - Asteroids](https://github.com/MiSTer-devel/Arcade-Asteroids_MiSTer){target=_blank}
 * [Arcade - Asteroids Deluxe](https://github.com/MiSTer-devel/Arcade-AsteroidsDeluxe_MiSTer){target=_blank}
 * [Arcade - A Tetris](https://github.com/MiSTer-devel/Arcade-ATetris_MiSTer){target=_blank} T65
@@ -116,20 +141,25 @@ See: [Cores supporting RTC](../cores/features/rtcsupport.md){target=_blank}
 * [NES](https://github.com/MiSTer-devel/NES_MiSTer){target=_blank} Custom MOS 6502 (aka Ricoh 2A03)
 
 ### 6522 Versatile Interface Adapter
+
 * [Vectrex](https://github.com/MiSTer-devel/Vectrex_MiSTer){target=_blank} MC68A09
 
 ### 6532 RIOT - RAM + Input/Output + Timer
+
 * [Atari 2600](https://github.com/MiSTer-devel/Atari2600_MiSTer){target=_blank}
 * [Atari 7800](https://github.com/MiSTer-devel/Atari7800_MiSTer){target=_blank}
 
 ## Motorola 
 ### 6809
+
 * [Vectrex](https://github.com/MiSTer-devel/Vectrex_MiSTer){target=_blank} MC68A09
 
 ### 6840 Programmable Timer Module
+
 * [Arcade - Frenzy](https://github.com/MiSTer-devel/Arcade-Frenzy_MiSTer){target=_blank}
 
 ### 68000
+
 * [Mega CD](https://github.com/MiSTer-devel/MegaCD_MiSTer){target=_blank}
 * [NeoGeo](https://github.com/MiSTer-devel/NeoGeo_MiSTer){target=_blank}
 * [Sega Genesis](https://github.com/MiSTer-devel/Genesis_MiSTer){target=_blank}
@@ -137,52 +167,66 @@ See: [Cores supporting RTC](../cores/features/rtcsupport.md){target=_blank}
 
 ## NEC 
 ### uCOM-43
+
 * [Tomy Scramble](https://github.com/MiSTer-devel/TomyScramble_MiSTer){target=_blank}
 
 ### µPD77C25 aka SNES cart IC DSP1, DSP2, DSP3, DSP4
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank}
 
 ### µPD96050 aka SNES cart IC ST010
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank}
 
 ## Nintendo
-### OBC1 
+### OBC1
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank} SNES Cart IC
 
 ### PPU - Pixel Processing Unit
+
 * [NES](https://github.com/MiSTer-devel/NES_MiSTer){target=_blank} RP2A03G
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank} S-PPU2
 
 ### S-SMP Audio
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank}
 
-### SDD1 
+### SDD1
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank} SNES Cart IC
 
-### GSU-1 
+### GSU-1
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank} Superfx SNES Cart IC 
 
 ## SNK 
 ### Graphics - SNK PRO-A0, SNK LSPC2-A2, SNK PRO-B0, NEO-B1, NEO-GRC
+
 * [NeoGeo](https://github.com/MiSTer-devel/NeoGeo_MiSTer){target=_blank}
 
 ## Texas Instruments
 ### SN76489 Sound
+
 * [ColecoVision & SG-1000](https://github.com/MiSTer-devel/ColecoVision_MiSTer){target=_blank}
 * [Sega Genesis](https://github.com/MiSTer-devel/Genesis_MiSTer){target=_blank}
 * [Sega Master System & Game Gear](https://github.com/MiSTer-devel/SMS_MiSTer){target=_blank}
 
 ### TMS9928A NTSC Graphics
+
 * [ColecoVision & SG-1000](https://github.com/MiSTer-devel/ColecoVision_MiSTer){target=_blank}
 
 ### TMS9929A PAL Graphics
+
 * [ColecoVision & SG-1000](https://github.com/MiSTer-devel/ColecoVision_MiSTer){target=_blank}
 
 ## WDC 65C816
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank} Ricoh 5A22 - Custom WDC 65C816
 
 
 ## YM2149 (AY-3-8910) Sound
+
 * [Arcade - Arkanoid](https://github.com/MiSTer-devel/Arcade-Arkanoid_MISTer){target=_blank}
 * [Arcade - Bagman](https://github.com/MiSTer-devel/Arcade-Bagman_MiSTer){target=_blank}
 * [Bally Midway MCR-1](https://github.com/MiSTer-devel/Arcade-MCR1_MiSTer){target=_blank}
@@ -196,25 +240,32 @@ See: [Cores supporting RTC](../cores/features/rtcsupport.md){target=_blank}
 
 ## Yamaha
 ### YM2151 (aka JT51)
+
 * [Atari 7800](https://github.com/MiSTer-devel/Atari7800_MiSTer){target=_blank}
 
 ### YM2413 FM
+
 * [Sega Master System & Game Gear](https://github.com/MiSTer-devel/SMS_MiSTer){target=_blank}
 
 ### YM2610 Audio
+
 * [NeoGeo](https://github.com/MiSTer-devel/NeoGeo_MiSTer){target=_blank}
 
 ### YM2612 Audio
+
 * [Sega Genesis](https://github.com/MiSTer-devel/Genesis_MiSTer){target=_blank}
 
 ### YM3438 Audio
+
 * [Sega Genesis](https://github.com/MiSTer-devel/Genesis_MiSTer){target=_blank}
 
 ### YM7101 VDP Video Display Processor
+
 * [Sega Genesis](https://github.com/MiSTer-devel/Genesis_MiSTer){target=_blank}
 
 ## Zilog
 ## Z80
+
 * [Astrocade](https://github.com/MiSTer-devel/Astrocade_MiSTer){target=_blank}
 * [ColecoVision & SG-1000](https://github.com/MiSTer-devel/ColecoVision_MiSTer){target=_blank}
 * [Gameboy](https://github.com/MiSTer-devel/Gameboy_MiSTer){target=_blank} Custom Z80 Sharp LR35902
@@ -241,6 +292,7 @@ See: [Cores supporting RTC](../cores/features/rtcsupport.md){target=_blank}
 * [Arcade - Galaga](https://github.com/MiSTer-devel/Arcade-Galaga_MiSTer){target=_blank} T80
 
 ## Simple Logic
+
 * [Arcade - Breakout](https://github.com/MiSTer-devel/Arcade-Breakout_MiSTer){target=_blank} SN74107, SN74153, SN74175, SN74192, SN74193, SN74279, SN7448, SN7474, SN7483, SN7490, SN7493
 * [Arcade - Breakout](https://github.com/MiSTer-devel/Arcade-Breakout_MiSTer){target=_blank} DM9310, DM9312, DM9316, DM9602, S82S16, Astable 555 Timer, Oneshot 555 Timer,  NAND, NOR, Toggle FF
 * [Arcade - Computer Space](https://github.com/MiSTer-devel/Arcade-ComputerSpace_MiSTer){target=_blank} 74161 16-bit
@@ -253,6 +305,7 @@ See: [SYS HPS IO](hps_io.md){target=_blank} for ARM <-> FPGA communication detai
 See: [Cores Supporting ADC](https://github.com/MiSTer-devel/Main_MiSTer/wiki/Cores-Supporting-ADC){target=_blank}
 
 ## Audio Filters in Menu
+
 * [Sega Genesis](https://github.com/MiSTer-devel/Genesis_MiSTer){target=_blank}
 
 ## Controllers - Original Console Controllers
@@ -260,85 +313,107 @@ See SNAC: [User Port (Serial IO)](https://github.com/MiSTer-devel/Main_MiSTer/wi
 
 ## DIP Switches in Menu
 Many Arcade Games
+
 * [Arcade - Galaga](https://github.com/MiSTer-devel/Arcade-Galaga_MiSTer){target=_blank} T80
 
 ## Rotate the Screen
+
 * [Atari Lynx](https://github.com/MiSTer-devel/AtariLynx_MiSTer){target=_blank}
 
 ## Save States
+
 * [Gameboy](https://github.com/MiSTer-devel/Gameboy_MiSTer){target=_blank}
 
 ## Secondary SD Card
 See: [Secondary SD card](https://github.com/MiSTer-devel/Main_MiSTer/wiki/Secondary-SD-card){target=_blank}
 
 ## Gameboy Link Port via USERIO
+
 * [Gameboy](https://github.com/MiSTer-devel/Gameboy_MiSTer){target=_blank}
 
 ## Cheats
+
 * [Gameboy](https://github.com/MiSTer-devel/Gameboy_MiSTer){target=_blank}
 * [Sega Master System & Game Gear](https://github.com/MiSTer-devel/SMS_MiSTer){target=_blank}
 * [NES](https://github.com/MiSTer-devel/NES_MiSTer){target=_blank}
 * [Turbo Grafx 16](https://github.com/MiSTer-devel/TurboGrafx16_MiSTer){target=_blank}
 
 ## FPGA Only Systems (never manufactured as IC's)
+
 * [Chip 8](https://github.com/MiSTer-devel/Chip8_MiSTer){target=_blank}
 * [Epoch Galaxy 2](https://github.com/MiSTer-devel/EpochGalaxy2_MiSTer){target=_blank}
 * [Flappy Bird](https://github.com/MiSTer-devel/FlappyBird_MiSTer){target=_blank}
 * [Life](https://github.com/MiSTer-devel/Life_MiSTer){target=_blank}
 
 ## Joystick - Fixed 4 & 8 way
+
 * [Arcade - A Tetris](https://github.com/MiSTer-devel/Arcade-ATetris_MiSTer){target=_blank} T65
 
 ## Mouse
+
 * [SNES](https://github.com/MiSTer-devel/SNES_MiSTer){target=_blank}
 * [Turbo Grafx 16](https://github.com/MiSTer-devel/TurboGrafx16_MiSTer){target=_blank}
 
 ## OSD Settings
+
 * [Chess](https://github.com/MiSTer-devel/Chess_MiSTer){target=_blank}
 
 ## Random Number Generator
+
 * [Life](https://github.com/MiSTer-devel/Life_MiSTer){target=_blank}
 
 ## Read CUE+(Image/Track)
+
 * [Mega CD](https://github.com/MiSTer-devel/MegaCD_MiSTer){target=_blank}
 * [Turbo Grafx 16](https://github.com/MiSTer-devel/TurboGrafx16_MiSTer){target=_blank}
 
 ## ROMs With and without Headers
+
 * [Turbo Grafx 16](https://github.com/MiSTer-devel/TurboGrafx16_MiSTer){target=_blank}
 
 ## Save Games
+
 * [NES](https://github.com/MiSTer-devel/NES_MiSTer){target=_blank}
 
 ## Save States
+
 * [NES](https://github.com/MiSTer-devel/NES_MiSTer){target=_blank}
 
 ## SDRAM
 See: [Cores that use SDRAM](https://github.com/MiSTer-devel/Main_MiSTer/wiki/Cores-that-use-SDRAM){target=_blank}
 
 ## Speech
+
 * [Arcade - Bagman](https://github.com/MiSTer-devel/Arcade-Bagman_MiSTer){target=_blank}
 
 ## SPI
+
 * [Arduboy](https://github.com/MiSTer-devel/Arduboy_MiSTer){target=_blank}
 
 ## Two BIOS Options
+
 * [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer){target=_blank} (Optional)
 * [Turbo Grafx 16](https://github.com/MiSTer-devel/TurboGrafx16_MiSTer){target=_blank}
 
 ## Two Displays (HDMI + VGA)
+
 * [Gameboy Advance 2P](https://github.com/MiSTer-devel/GBA_MiSTer/tree/GBA2P){target=_blank}
 
 ## Two Systems Simultaneously
+
 * [Gameboy 2P](https://github.com/MiSTer-devel/Gameboy_MiSTer/tree/Gameboy2P){target=_blank}
 * [Gameboy Advance 2P](https://github.com/MiSTer-devel/GBA_MiSTer/tree/GBA2P){target=_blank}
 
 ## Vector Graphics
+
 * [Vectrex](https://github.com/MiSTer-devel/Vectrex_MiSTer){target=_blank}
 * [Arcade - Asteroids Deluxe](https://github.com/MiSTer-devel/Arcade-AsteroidsDeluxe_MiSTer){target=_blank}
 * [Arcade - Black Widow](https://github.com/MiSTer-devel/Arcade-BlackWidow_MiSTer){target=_blank}
 
 ## Wave based Sound Generator
+
 * [Arcade - Dig Dug](https://github.com/MiSTer-devel/Arcade-DigDug_MiSTer){target=_blank} T80
 
 ## XML ROM Configuration files?
+
 * [NeoGeo](https://github.com/MiSTer-devel/NeoGeo_MiSTer){target=_blank}

--- a/docs/developer/emu.md
+++ b/docs/developer/emu.md
@@ -218,6 +218,7 @@ For full understanding of the SDRAM interface you will need to look at the speci
 Look through the data sheet for the [32MB](https://github.com/MiSTer-devel/Main_MiSTer/wiki/files/AS4C16M16SA-V3.0_March%202015.pdf){target=_blank} module. The 64MB module data sheet isn't as detailed.
 
 Some examples of SDRAM modules:
+
 * single port direct usage: [Gameboy](https://github.com/MiSTer-devel/Gameboy_MiSTer/blob/master/rtl/sdram.sv){target=_blank}
 * multi port request/response: [Gameboy Advance](https://github.com/MiSTer-devel/GBA_MiSTer/blob/master/rtl/sdram.sv){target=_blank}
 * complex bank machine: [JT Frame](https://github.com/jotego/jtframe/blob/master/hdl/sdram/jtframe_sdram_bank.v){target=_blank}

--- a/docs/developer/mra.md
+++ b/docs/developer/mra.md
@@ -105,6 +105,7 @@ end
 ```
 
 ### Explanation for XML elements and attributes
+
 * **name**: As an element this indicates how the rom should be called. The value should be taken from MAME. As an attribute this indicates an external rom file (or part thereof) that should be loaded by MiSTer.
 * **mratimestamp**: This indicates the date on which the *.mra file was created (useful for other users to determine if there is a newer version of the *.mra file available to which they should upgrade). The date format is yyyymmdd.
 * **mameversion**: This indicates on which version of a MAME romset the *.mra file is based (which version was used for testing). The dot in MAME's version numbering is omitted.

--- a/docs/developer/porting.md
+++ b/docs/developer/porting.md
@@ -6,6 +6,7 @@ We will use [ZX Spectrum](https://github.com/MiSTer-devel/ZX-Spectrum_MISTer){ta
 Most of the sources of the Framework are located in [sys](https://github.com/MiSTer-devel/ZX-Spectrum_MISTer/tree/master/sys){target=_blank} folder.
 
 Usually, for a new project, you need to take following files/folders:
+
 * sys folder
 * jtag.cdf
 * jtag_lite.cdf
@@ -172,6 +173,7 @@ Make sure you set correct mode signed/unsigned, otherwise audio will be distorte
 There is a supplementary module **hps_io.v** which is also required to use in the same entity (see zxspectrum.sv). It provides in/out control from ARM side. Most signals are same or similar to MiST (user_io+data_io or mist_io modules) signals. So, if the core is ported from MiST, it in most cases it's 1:1 signal connections.
 
 MiSTer has some changes/improvements over original MiST io modules:
+
 * Supports up to 4 images mount at the same time (MiST has only 1). Set module parameter VDNUM to 2..4 if more than 1 mounted image is required. If VDNUM=1 then related signals are same as in MiST.
 * Due to SD card on MiSTer uses multiple partitions and holds other vital to MiSTer parts, access to whole SD card from cores is not available in MiSTer. Only the access to image files is possible. Cores requiring direct access to whole SD card should be redesigned to access to images only.
 * Main MiSTer file system on SD card is exFAT which supports files bigger than 4GB.


### PR DESCRIPTION
For whatever reason this markdown parser appears to mishandle lists if they are preceded by a normal text line (this does not seem to apply to headers). I went through and fixed all of the lists, and added spaces between the headers and lists in the scenarios where that occurred, in order to maintain consistency.