### PR TITLE
Added SHA1 checksums to Quartus download links

### DIFF
--- a/docs/developer/mistercompile.md
+++ b/docs/developer/mistercompile.md
@@ -4,9 +4,10 @@ MiSTer uses a combination of various compiled binaries in the finished product. 
 
 The vast majority of MiSTer FPGA cores currently use Quartus 17.0.2 for compilation. Here are the download links for both Windows and Linux:
 
-[Windows Download](https://download.altera.com/akdlm/software/acdsinst/17.0std.2/602/ib_tar/Quartus-lite-17.0.2.602-windows.tar){target=_blank}
-
-[Linux Download](https://download.altera.com/akdlm/software/acdsinst/17.0std.2/602/ib_tar/Quartus-lite-17.0.2.602-linux.tar){target=_blank}
+| Download URL                                                                                                                           | SHA1 Checksum                              |
+|----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| [Linux](https://download.altera.com/akdlm/software/acdsinst/17.0std.2/602/ib_tar/Quartus-lite-17.0.2.602-linux.tar){target=_blank}     | `02aebab728d54e3ca8660d2646fdf93bc669b0ac` |
+| [Windows](https://download.altera.com/akdlm/software/acdsinst/17.0std.2/602/ib_tar/Quartus-lite-17.0.2.602-windows.tar){target=_blank} | `01d1f9cea037cf4b8c666da1193f94ba626b6fb3` |
 
 The Linux version is intended to work with Ubuntu 18.xx, you may have to adjust by downloading some missing dependencies if you use a newer version or another distribution.
 


### PR DESCRIPTION
Adds SHA1 checksum for the Quartus download links to the documentation.

The checksums where sourced from _"Intel® Quartus® Prime Lite Edition Software Update 2 (Device support included)"_ found under the _"Updates"_ tab of https://www.intel.com/content/www/us/en/software-kit/669553/intel-quartus-prime-lite-edition-design-software-version-17-0-for-linux.html and https://www.intel.com/content/www/us/en/software-kit/669557/intel-quartus-prime-lite-edition-design-software-version-17-0-for-windows.html

Those pages also contain the following notice:

> The Intel® Quartus® Prime Lite Edition Design Software, Version 17.0 is subject to removal from the web when support for all devices in this release are available in a newer version, or all devices supported by this version are obsolete.

It would be ideal to have this checksum directly in the Misters documentation so these files can still be verified if/when the official download link stops working.