### PR TITLE
New redump URL

### DIFF
--- a/docs/cores/highlights/psx.md
+++ b/docs/cores/highlights/psx.md
@@ -30,7 +30,7 @@ You can load Playstation memory card files (.mcd or .sav) manually in the OSD in
 
 Some games used a kind of copy protection with what was called "Libcrypt" and they will not work if it's not circumvented.
 
-You can provide an .sbi file to do that. If there is an .sbi file [(the whole collection can be downloaded from redump.org)](http://redump.org/sbi/psx/){target=_blank} next to a .cue with the same name, it will then be loaded automatically when mounting the CD image.
+You can provide an .sbi file to do that. If there is an .sbi file [(the whole collection can be downloaded from redump.info)](https://redump.info/sbi/psx/){target=_blank} next to a .cue with the same name, it will then be loaded automatically when mounting the CD image.
 
 ## Audio and Video Options
 


### PR DESCRIPTION
Redump has moved from redump.org to redump.info (now with https!), this updates the SBI download link